### PR TITLE
Make renderEmbedScratch a static function

### DIFF
--- a/EmbedScratch.php
+++ b/EmbedScratch.php
@@ -31,7 +31,7 @@ class EmbedScratch{
 	    return true;
 	}
 	
-	static function renderEmbedScratch ($input, $argv, $parser) {
+	public static function renderEmbedScratch ($input, $argv, $parser) {
 		$project = '';
 		$width = $width_max = 485;
 		$height = $height_max = 402;

--- a/EmbedScratch.php
+++ b/EmbedScratch.php
@@ -31,7 +31,7 @@ class EmbedScratch{
 	    return true;
 	}
 	
-	function renderEmbedScratch ($input, $argv, $parser) {
+	static function renderEmbedScratch ($input, $argv, $parser) {
 		$project = '';
 		$width = $width_max = 485;
 		$height = $height_max = 402;


### PR DESCRIPTION
This function is being statically called otherwise and you will be shown this error if you have error logging active in your LocalSettings.php-
``PHP Deprecated: Non-static method EmbedScratch::renderEmbedSnap() should not be called statically in /srv/mediawiki/w/includes/parser/Parser.php on line 4798``
.

This is related to snapwiki/SnapProjectEmbed#13.